### PR TITLE
Add Jenkins repository for parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,18 @@
       <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
-  
+
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
This repository is required, otherwise a local build fails.

Maybe some developers have it configured in a central settings.xml and therefore don't notice its absence.