### PR TITLE
Use JUnit 4 instead of JUnit 3 for tests

### DIFF
--- a/src/test/java/org/jvnet/hudson/crypto/PKIXTest.java
+++ b/src/test/java/org/jvnet/hudson/crypto/PKIXTest.java
@@ -2,7 +2,7 @@ package org.jvnet.hudson.crypto;
 
 import static org.junit.Assert.assertThrows;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.security.GeneralSecurityException;
 import java.security.cert.CertPathValidatorException;
@@ -14,10 +14,11 @@ import java.util.List;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class PKIXTest extends TestCase {
+public class PKIXTest {
     /**
      * Makes sure valid certificate chain validates.
      */
+    @Test
     public void testPathValidation() throws Exception {
         X509Certificate site = load("site.crt");
         X509Certificate sun = load("sun.crt");

--- a/src/test/java/org/jvnet/hudson/crypto/RSAPublicKeyUtilTest.java
+++ b/src/test/java/org/jvnet/hudson/crypto/RSAPublicKeyUtilTest.java
@@ -1,6 +1,8 @@
 package org.jvnet.hudson.crypto;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAPublicKey;
@@ -8,7 +10,8 @@ import java.security.interfaces.RSAPublicKey;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class RSAPublicKeyUtilTest extends TestCase {
+public class RSAPublicKeyUtilTest {
+    @Test
     public void testReadPublicKey() throws Exception {
         RSAPublicKey p = (RSAPublicKey) RSAPublicKeyUtil.readPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCzBy1GEihAxSgrsEANgCxYwxS8Yy0U7cKq/1MMtr4/IrW2m2rzDcr4a7ZG/p/XrchCMn5eIekq1dYHsB0hY81iJr7jMZi7XbQx/LohF833YhIRctALpNzPunqBxZvOUVDib/dfX6LuoZTOojI/W5UPYrzAjyrjKMQvF5Mo0LaZ6eN1LElVaGzWExqO7mNkOrJY3IVurPu81mK4E+59FHTuB/oIawHUlxjMgBFPGKZBmb0cyVyViEmY6E78bNcN+frdSxZ72gcK/J7l1gfGz6YNQX6hKA+3v2O+/6pHf282W2hy0u4nw2DTs5NrsTnG8koiivilXC3VbhgVmQnUFKx5 kohsuke@griffon.2013");
         System.out.println(p);
@@ -18,6 +21,7 @@ public class RSAPublicKeyUtilTest extends TestCase {
         assertEquals(p.getPublicExponent(), new BigInteger("65537"));
     }
 
+    @Test
     public void testGetFingerPrint() throws Exception {
         RSAPublicKey p = (RSAPublicKey) RSAPublicKeyUtil.readPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCzBy1GEihAxSgrsEANgCxYwxS8Yy0U7cKq/1MMtr4/IrW2m2rzDcr4a7ZG/p/XrchCMn5eIekq1dYHsB0hY81iJr7jMZi7XbQx/LohF833YhIRctALpNzPunqBxZvOUVDib/dfX6LuoZTOojI/W5UPYrzAjyrjKMQvF5Mo0LaZ6eN1LElVaGzWExqO7mNkOrJY3IVurPu81mK4E+59FHTuB/oIawHUlxjMgBFPGKZBmb0cyVyViEmY6E78bNcN+frdSxZ72gcK/J7l1gfGz6YNQX6hKA+3v2O+/6pHf282W2hy0u4nw2DTs5NrsTnG8koiivilXC3VbhgVmQnUFKx5 kohsuke@griffon.2013");
         assertEquals("f7:7a:42:76:79:e8:8a:1a:4a:32:0c:b3:f9:3b:53:d4",RSAPublicKeyUtil.getFingerPrint(p));


### PR DESCRIPTION
## Use JUnit 4 instead of JUnit 3 for tests

The tests were already using the JUnit 4 assertThrows method.  Let's convert them the rest of the way to JUnit 4.

### Testing done

Confirmed that `mvn clean verify` passes and that the expected tests are executed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
